### PR TITLE
Handle multiple recipes per meta.yaml correctly.

### DIFF
--- a/action/create_feedstock.sh
+++ b/action/create_feedstock.sh
@@ -1,35 +1,38 @@
 #!/bin/bash
 
 META_PATH=$1
-FEEDSTOCK_NAME=$(yq eval '.id' /github/workspace/$META_PATH)
-REPO_NAME=$FEEDSTOCK_NAME-feedstock
-RECIPES_DIR=$(dirname /github/workspace/$META_PATH)
+RECIPES_DIR=$(dirname "/github/workspace/$META_PATH")
 
-gh api repos/pangeo-forge/$REPO_NAME --silent
-
-if [[ $? == 0 ]]
-then
+create_feedstock () {
+  if gh api "repos/pangeo-forge/$REPO_NAME" --silent
+  then
     echo "pangeo-forge/$REPO_NAME already exists, your id in meta.yaml should be unique"
     exit 1
-fi
+  fi
 
-git init /$REPO_NAME && cd /$REPO_NAME
+  git init "/$REPO_NAME" && cd "/$REPO_NAME" || exit
 
-gh repo create pangeo-forge/$REPO_NAME -d 'The $FEEDSTOCK_NAME Feedstock' --template pangeo-forge/feedstock-template --public --confirm
+  gh repo create "pangeo-forge/$REPO_NAME" -d "The $FEEDSTOCK_NAME Feedstock" --template pangeo-forge/feedstock-template --public --confirm
 
-git fetch --all && git pull origin main && git checkout main
+  git fetch --all && git pull origin main && git checkout main
 
-git remote set-url origin https://pangeo-forge:$GITHUB_TOKEN@github.com/pangeo-forge/$REPO_NAME.git
+  git remote set-url origin "https://pangeo-forge:$GITHUB_TOKEN@github.com/pangeo-forge/$REPO_NAME.git"
 
-mkdir feedstock
+  mkdir feedstock
 
-cp -r $RECIPES_DIR/* feedstock/
+  cp -r "$RECIPES_DIR/*" feedstock/
 
-cat <<EOF > ./README.md
-# $REPO_NAME
-
-This repository has been generated via the [\`feedstock-creation-action\`](https://github.com/pangeo-forge/feedstock-creation-action) for the $FEEDSTOCK_NAME Feedstock
+  cat <<EOF > ./README.md
+  # $REPO_NAME
+  This repository has been generated via the [\`feedstock-creation-action\`](https://github.com/pangeo-forge/feedstock-creation-action) for the $FEEDSTOCK_NAME Feedstock
 
 EOF
 
-git add -A && git commit -m "Add Feedstock files" && git push
+  git add -A && git commit -m "Add Feedstock files" && git push
+}
+
+while IFS= read -r value; do
+    FEEDSTOCK_NAME="$value"
+    REPO_NAME=$FEEDSTOCK_NAME-feedstock
+    create_feedstock
+done < <(yq eval '.recipes[].id' /github/workspace/"$META_PATH")

--- a/example-feedstock/meta.yaml
+++ b/example-feedstock/meta.yaml
@@ -2,7 +2,6 @@ title: "A Test Feedstock of Recipes"
 description: "Analysis-ready Zarr datasets derived from a dataset"
 pangeo_forge_version: "0.3.3"
 pangeo_notebook_version: "2021.05.04"
-id: a-test-bunch-of-recipes
 recipes:
   - id: a-recipe
     object: "recipe:recipe"


### PR DESCRIPTION
## What I am changing
Linting updates using ShellCheck.
Run feedstock creation for each recipe listed in the `meta.yaml` rather than using a top level `id` value.  See this [ADR](https://github.com/pangeo-forge/roadmap/blob/master/doc/adr/0002-use-meta-yaml-to-track-feedstock-metadata.md) for more `meta.yaml` structural details.

## How I did it

## How you can test it
Run `make feedstock`.
