### PR TITLE
Remove `$RECIPES_DIR` after feedstock creation

### DIFF
--- a/action/create_feedstock.sh
+++ b/action/create_feedstock.sh
@@ -47,4 +47,5 @@ while IFS= read -r value; do
     FEEDSTOCK_NAME="$value"
     REPO_NAME=$FEEDSTOCK_NAME-feedstock
     create_feedstock
+    rm -r $RECIPES_DIR
 done < <(yq eval '.recipes[].id' /github/workspace/"$META_PATH")


### PR DESCRIPTION
## What I am changing

https://github.com/conda-forge/staged-recipes/tree/main/recipes does not maintain recipe PR directories following feedstock creation.

When https://github.com/pangeo-forge/staged-recipes/pull/36 was merged, the PR directory was not removed: https://github.com/pangeo-forge/staged-recipes/tree/master/recipes

I assume we will also want to remove PR directories after feedstock creation.

## How I did it

Added one line to `create_feedstock.sh`

## How you can test it

Run `make feedstock` from a local copy of this repo, and note that `example-feedstock` directory is removed after the feedstock repo is created.

cc @sharkinsspatial @rabernat
